### PR TITLE
Create Donation Resource with Role-Based Access

### DIFF
--- a/app/Enums/DonationStatusEnum.php
+++ b/app/Enums/DonationStatusEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum DonationStatusEnum: string
+{
+    case PENDING = "pending";
+    case COMPLETED = "completed";
+    case CANCELLED = "cancelled";
+}

--- a/app/Filament/Resources/DonationResource.php
+++ b/app/Filament/Resources/DonationResource.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Enums\DonationStatusEnum;
+use App\Enums\TransactionTypeEnum; // Ensure this Enum is imported if used
+use App\Filament\Resources\DonationResource\Pages;
+use App\Models\Donation;
+use App\Models\Address;
+use App\Models\Agent;
+use App\Models\Transaction; // Ensure this Model is imported if used
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class DonationResource extends Resource
+{
+    protected static ?string $model = Donation::class;
+    protected static ?string $navigationIcon = 'heroicon-o-gift';
+    protected static ?string $navigationGroup = 'Donations Management'; // Changed to English
+    protected static ?string $modelLabel = 'Donation'; // Changed to English
+    protected static ?string $pluralModelLabel = 'Donations'; // Changed to English
+
+    /**
+     * Get the navigation badge for the resource.
+     * Only visible to admins.
+     */
+    public static function getNavigationBadge(): ?string
+    {
+        if (!auth()->check()) {
+            return null;
+        }
+        if (auth()->user()->role !== 'admin') {
+            return null;
+        }
+        return static::getModel()::count();
+    }
+
+    /**
+     * Determine if the user can edit a record.
+     * Only admins can edit donations.
+     */
+    public static function canEdit(\Illuminate\Database\Eloquent\Model $record): bool
+    {
+        return auth()->user()->role === "admin";
+    }
+
+    /**
+     * Define the form schema for creating and editing donations.
+     */
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Section::make('Donation Details')->schema([ // Changed to English
+                    Forms\Components\Select::make("user_id")
+                        ->relationship('user', "name")
+                        ->label("Donor") // Changed to English
+                        ->required()
+                        ->searchable()
+                        ->preload(),
+
+                    Forms\Components\Select::make("address_id")
+                        ->label("Pickup Address") // Changed to English
+                        ->options(
+                            Address::all()
+                                ->mapWithKeys(function ($address) {
+                                    return [
+                                        $address->id =>
+                                        'City: ' . $address->city . // Changed to English
+                                            ', Governorate: ' . $address->governate . // Changed to English
+                                            ', Street: ' . $address->street . // Changed to English
+                                            ($address->building_no ? ', Building No: ' . $address->building_no : '') // Changed to English
+                                    ];
+                                })
+                                ->toArray()
+                        )
+                        ->required()
+                        ->placeholder('Select a pickup address'), // Changed to English
+
+                    Forms\Components\TextInput::make('pieces')
+                        ->label('Number of Pieces') // Changed to English
+                        ->numeric()
+                        ->minValue(0)
+                        ->nullable(),
+
+                    Forms\Components\Textarea::make('description')
+                        ->label('Description') // Changed to English
+                        ->maxLength(65535)
+                        ->columnSpanFull()
+                        ->nullable(),
+
+                    Forms\Components\Select::make("status")
+                        ->options(DonationStatusEnum::class)
+                        ->label('Status') // Changed to English
+                        ->required()
+                        ->default(DonationStatusEnum::PENDING->value),
+
+                    Forms\Components\Select::make('agent_id')
+                        ->relationship('agent.user', 'name')
+                        ->label('Assigned Agent') // Changed to English
+                        ->placeholder('No agent assigned') // Changed to English
+                        ->nullable()
+                        ->searchable()
+                        ->preload()
+                        ->visible(auth()->user()->role === 'admin'),
+                ])->columns(2),
+            ]);
+    }
+
+    /**
+     * Define the table columns and actions for displaying donations.
+     */
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make("user.name")
+                    ->label("Donor") // Changed to English
+                    ->searchable()
+                    ->sortable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->label('Status') // Changed to English
+                    ->badge()
+                    ->color(fn(string $state): string => match ($state) {
+                        DonationStatusEnum::PENDING->value => 'warning',
+                        DonationStatusEnum::COMPLETED->value => 'success',
+                        DonationStatusEnum::CANCELLED->value => 'danger',
+                        default => 'gray', // Default color for unexpected values
+                    })
+                    ->sortable(),
+                Tables\Columns\TextColumn::make("pieces")
+                    ->label("Number of Pieces") // Changed to English
+                    ->numeric()
+                    ->sortable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make("description")
+                    ->label('Description') // Changed to English
+                    ->limit(50)
+                    ->tooltip(fn(Donation $record): string => $record->description ?: 'No description') // Changed to English
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make("address.city")
+                    ->label('Pickup Address Details') // Changed to English
+                    ->description(function (Donation $record) {
+                        if ($record->address) {
+                            return 'City: ' . $record->address->city . // Changed to English
+                                ', Governorate: ' . $record->address->governate . // Changed to English
+                                ', Street: ' . $record->address->street . // Changed to English
+                                ($record->address->building_no ? ', Building No: ' . $record->address->building_no : ''); // Changed to English
+                        }
+                        return 'No address'; // Changed to English
+                    })
+                    ->searchable([
+                        'address.city',
+                        'address.governate',
+                        'address.street',
+                        'address.building_no'
+                    ])
+                    ->sortable('address.city'),
+                Tables\Columns\TextColumn::make('agent.user.name')
+                    ->label('Assigned Agent Name') // Changed to English
+                    ->placeholder('No agent assigned') // Changed to English
+                    ->sortable()
+                    ->searchable()
+                    ->visible(auth()->user()->role === 'admin'),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Creation Date') // Changed to English
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->label('Filter by Status') // Changed to English
+                    ->options(DonationStatusEnum::class)
+                    ->attribute('status'),
+
+                Tables\Filters\SelectFilter::make('user_id')
+                    ->relationship('user', 'name')
+                    ->label('Filter by Donor') // Changed to English
+                    ->searchable()
+                    ->preload(),
+
+                Tables\Filters\SelectFilter::make('agent_id')
+                    ->relationship('agent.user', 'name')
+                    ->label('Filter by Assigned Agent') // Changed to English
+                    ->searchable()
+                    ->preload()
+                    ->visible(auth()->user()->role === 'admin'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\DeleteAction::make(),
+
+                Tables\Actions\Action::make("assign_agent")
+                    ->label("Assign Agent") // Changed to English
+                    ->icon("heroicon-o-user-plus")
+                    ->color("primary")
+                    ->form([
+                        Forms\Components\Select::make("agent_id")
+                            ->label("Select Agent") // Changed to English
+                            ->options(
+                                Agent::with('user')->get()->pluck('user.name', 'id')->toArray()
+                            )
+                            ->required(),
+                    ])
+                    ->action(function (Donation $donation, $data) {
+                        $donation->agent_id = $data["agent_id"];
+                        $donation->save();
+                        Notification::make()
+                            ->title("Agent assigned successfully.") // Changed to English
+                            ->success()
+                            ->send();
+                    })
+                    ->visible(
+                        fn(Donation $donation) =>
+                        auth()->user()->role === "admin" &&
+                            is_null($donation->agent_id)
+                    ),
+
+                Tables\Actions\Action::make("receive_donation")
+                    ->label("Receive Donation") // Changed to English
+                    ->icon("heroicon-m-hand-raised")
+                    ->color("success")
+                    ->action(function (Donation $donation) {
+                        $userId = auth()->id();
+                        $agent = Agent::where("user_id", $userId)->first();
+
+                        if (!$agent) {
+                            Notification::make()
+                                ->title("Error: Agent not found for current user.") // Changed to English
+                                ->danger()
+                                ->send();
+                            return;
+                        }
+
+                        $donation->agent_id = $agent->id;
+                        // The donation remains 'pending' until truly completed.
+                        $donation->save();
+                        Notification::make()
+                            ->title("Donation received (status remains pending).") // Changed to English
+                            ->success()
+                            ->send();
+                    })
+                    ->visible(
+                        fn(Donation $donation) => (auth()->user()->role === "agent" &&
+                            $donation->status === DonationStatusEnum::PENDING->value &&
+                            is_null($donation->agent_id)) // Agent can receive unassigned pending donations
+
+                    ),
+
+                Tables\Actions\Action::make("cancel_donation")
+                    ->label("Cancel Donation") // Changed to English
+                    ->icon("heroicon-m-x-circle")
+                    ->color("danger")
+                    ->action(function (Donation $donation) {
+                        $donation->status = DonationStatusEnum::CANCELLED->value;
+                        $donation->save();
+                        Notification::make()->title("Donation cancelled.")->success()->send(); // Changed to English
+                    })
+                    ->visible(
+                        fn(Donation $donation) =>
+                        $donation->status === DonationStatusEnum::PENDING->value &&
+                            (auth()->user()->role === "admin" || optional($donation->agent)->user_id === auth()->id())
+                    ),
+
+                Tables\Actions\Action::make("complete_donation")
+                    ->label("Complete Donation") // Changed to English
+                    ->icon("heroicon-o-check-circle")
+                    ->color("success")
+                    ->action(function (Donation $donation) {
+                        $donation->status = DonationStatusEnum::COMPLETED->value;
+                        $donation->save();
+
+                        // Create a transaction with zero points, as requested
+                        Transaction::create([
+                            'user_id' => $donation->user_id,
+                            'amount' => 0, // Zero points
+                            'type' => TransactionTypeEnum::CREDIT->value,
+                            'description' => 'Donation completed (no points awarded)', // Changed to English
+                        ]);
+
+                        Notification::make()->title("Donation completed.")->success()->send(); // Changed to English
+                    })
+                    ->visible(
+                        fn(Donation $donation) =>
+                        $donation->status === DonationStatusEnum::PENDING->value &&
+                            optional($donation->agent)->user_id === auth()->id()
+                    ),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    /**
+     * Define the resource's relation managers.
+     */
+    public static function getRelations(): array
+    {
+        return [
+            // No RelationManagers as requested
+        ];
+    }
+
+    /**
+     * Define the resource's pages.
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDonations::route('/'),
+            'create' => Pages\CreateDonation::route('/create'),
+            'edit' => Pages\EditDonation::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/DonationResource/Pages/CreateDonation.php
+++ b/app/Filament/Resources/DonationResource/Pages/CreateDonation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\DonationResource\Pages;
+
+use App\Filament\Resources\DonationResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDonation extends CreateRecord
+{
+    protected static string $resource = DonationResource::class;
+}

--- a/app/Filament/Resources/DonationResource/Pages/EditDonation.php
+++ b/app/Filament/Resources/DonationResource/Pages/EditDonation.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DonationResource\Pages;
+
+use App\Filament\Resources\DonationResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDonation extends EditRecord
+{
+    protected static string $resource = DonationResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/DonationResource/Pages/ListDonations.php
+++ b/app/Filament/Resources/DonationResource/Pages/ListDonations.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Filament\Resources\DonationResource\Pages;
+
+use App\Filament\Resources\DonationResource;
+use Filament\Actions;
+use Filament\Resources\Components\Tab;
+use Filament\Resources\Pages\ListRecords;
+use App\Enums\DonationStatusEnum;
+use App\Models\Donation;
+use Illuminate\Support\Collection; // Make sure Collection is imported if used in `getTabs` or other methods
+
+class ListDonations extends ListRecords
+{
+    protected static string $resource = DonationResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+
+    /**
+     * Define tabs for filtering donations based on user role.
+     * Admin users see no tabs, displaying the full table.
+     * Agent users see specific tabs for their assigned donations.
+     */
+    public function getTabs(): array
+    {
+        $userRole = auth()->user()->role;
+        $tabs = [];
+
+        // If the user is an admin, return an empty array of tabs.
+        // Filament will then display the default full table for admins.
+        if ($userRole === "admin") {
+            return [];
+        }
+        // If the user is an agent, define specific tabs for them.
+        elseif ($userRole === "agent") {
+            $agent = auth()->user()->agent ?? null;
+
+            // If the current user is an agent but doesn't have an agent record, show no tabs.
+            if (!$agent) {
+                return [];
+            }
+
+            $tabs["available"] = Tab::make("Available for Pickup")
+                ->badge(
+                    Donation::where("status", DonationStatusEnum::PENDING->value)
+                        ->whereNull('agent_id') // Donations not yet assigned to any agent
+                        ->count()
+                )
+                ->modifyQueryUsing(
+                    fn($query) =>
+                    $query->where("status", DonationStatusEnum::PENDING->value)
+                        ->whereNull('agent_id')
+                );
+
+            $tabs["my_donations"] = Tab::make("My Pending Donations")
+                ->badge(
+                    Donation::where('status', DonationStatusEnum::PENDING->value)
+                        ->whereHas('agent', fn($q) => $q->where('user_id', auth()->id())) // Donations assigned to current agent and still pending
+                        ->count()
+                )
+                ->modifyQueryUsing(
+                    fn($query) =>
+                    $query->where('status', DonationStatusEnum::PENDING->value)
+                        ->whereHas('agent', fn($query) => $query->where('user_id', auth()->id()))
+                );
+
+            $tabs["completed_by_me"] = Tab::make("Completed by Me")
+                ->badge(
+                    Donation::where("status", DonationStatusEnum::COMPLETED->value)
+                        ->whereHas('agent', fn($q) => $q->where('user_id', auth()->id())) // Donations completed by current agent
+                        ->count()
+                )
+                ->modifyQueryUsing(
+                    fn($query) =>
+                    $query->where("status", DonationStatusEnum::COMPLETED->value)
+                        ->whereHas('agent', fn($query) => $query->where('user_id', auth()->id()))
+                );
+
+            $tabs["cancelled_by_me"] = Tab::make("Cancelled by Me")
+                ->badge(
+                    Donation::where("status", DonationStatusEnum::CANCELLED->value)
+                        ->whereHas('agent', fn($q) => $q->where('user_id', auth()->id())) // Donations cancelled by current agent
+                        ->count()
+                )
+                ->modifyQueryUsing(
+                    fn($query) =>
+                    $query->where("status", DonationStatusEnum::CANCELLED->value)
+                        ->whereHas('agent', fn($query) => $query->where('user_id', auth()->id()))
+                );
+        }
+
+        return $tabs;
+    }
+}

--- a/app/Models/Donation.php
+++ b/app/Models/Donation.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class Donation extends Model
 {
     use HasFactory;
-    protected $fillable = ['user_id','address_id', 'pieces', 'description', 'image'];
+    protected $fillable = ['user_id', 'address_id', 'pieces', 'description', 'status'];
 
     public function user()
     {
@@ -26,6 +26,4 @@ class Donation extends Model
     {
         return $this->belongsTo(Agent::class);
     }
-
-
 }

--- a/database/migrations/2025_07_09_180210_add_status_to_donations_table.php
+++ b/database/migrations/2025_07_09_180210_add_status_to_donations_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('donations', function (Blueprint $table) {
+            // إضافة عمود 'status' كـ ENUM مع القيم المحددة
+            $table->enum('status', ['pending', 'completed', 'cancelled'])->default('pending')->after('description');
+            // يمكنك تغيير after('description') لوضع العمود في مكان آخر إذا أردت.
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('donations', function (Blueprint $table) {
+            // حذف عمود 'status' في حالة التراجع عن الـ migration
+            $table->dropColumn('status');
+        });
+    }
+};


### PR DESCRIPTION
Implemented a new Filament Donation Resource, similar to the Order Resource, allowing both agents and admins to manage donations with distinct access and functionalities tailored to their roles.